### PR TITLE
fix: made CONTRIBUTING.md link clickable in README

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -134,7 +134,7 @@ agribazaar/
 
 ## Contribution Guidelines
 
-Please refer to `CONTRIBUTING.md` for full guidelines.
+Please refer to [CONTRIBUTING.md](CONTRIBUTING.md) for full guidelines.
 
 ---
 


### PR DESCRIPTION
This PR updates the README.md to make the CONTRIBUTING.md reference a clickable link.

Related to #7
